### PR TITLE
Start ELF section search at index one

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+github_checks:
+    annotations: false


### PR DESCRIPTION
The zeroth ELF section index seems to be reserved and will never contain a valid section. From elf(5):
  > A section header table index is a subscript into this array. Some
  > section header table indices are reserved: the initial entry and the
  > indices between SHN_LORESERVE and SHN_HIRESERVE.  The initial entry
  > is used in ELF extensions for e_phnum, e_shnum, and e_shstrndx; in
  > other cases, each field in the initial entry is set to zero.

We do not have to check it when trying to find a section by name.